### PR TITLE
Add docker configuration for easy testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM php:7.4
+
+RUN apt update
+
+RUN apt install libffi-dev \
+    && docker-php-ext-configure ffi --with-ffi \
+    && docker-php-ext-install ffi
+
+
+RUN apt install libsdl2-2.0-0 -y
+RUN apt install libsdl2-image-2.0-0 -y
+RUN apt install libglu1 -y
+
+RUN apt install zip -y
+
+RUN apt install git -y
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+
+COPY . /usr/src/myapp
+
+WORKDIR /usr/src/myapp
+
+RUN composer install
+
+CMD ["php", "./app.php"]

--- a/README.md
+++ b/README.md
@@ -36,9 +36,14 @@ in **pure PHP**.
 - `composer install`
 - `php app.php`
 
+### Linux / Docker
+
+- `docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$DISPLAY -e XAUTHORITY=$XAUTHORITY $(docker build -q .)`
+
 ### MacOS
 
 - `brew install sdl2`
 - `brew install sdl2_image`
 - `composer install`
 - `php app.php`
+


### PR DESCRIPTION
We write the year 2020 and we should not start a game outside of a container.

This is just a very quick setup to get this demo running via docker, so people do not have to setup their own PHP7.4 FFI enviroment.

PS:
It works for me. Nice demo. I like your SDL wrapper.